### PR TITLE
feat: add initial ollama cf tunnel

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Ollama with Cloudflare Tunnel
+
+Run Ollama AI models locally with remote access via Cloudflare tunnels.
+
+## Prerequisites
+
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+## Services
+
+- **ollama**: AI model server with GPU support (port 11434)
+- **ollama-tunnel**: Secure Cloudflare tunnel for remote access
+
+## Setup
+
+1. Edit `cloudflared/config.yml` with your tunnel UUID and hostname
+2. Run `docker compose up -d`
+3. Access locally at `http://localhost:11434` or remotely via Cloudflare
+4. Check tunnel status: `docker compose logs ollama-tunnel`
+
+## Installing Models
+
+```bash
+# Start containers then run:
+bash ollama/models.sh
+```
+
+### Available Models
+- **LLMs**: llama3.2:1b, gemma3:1b, deepseek-r1:1.5b
+- **Embeddings**: nomic-embed-text, mxbai-embed-large
+- **Vision**: granite3.2-vision:2b
+
+### Customization
+- Edit `ollama/models.sh` to add/remove models
+- Uncomment models in the script to enable them
+- View installed models by uncommenting `ollama list` in the script
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+

--- a/cloudflared/config.yml
+++ b/cloudflared/config.yml
@@ -1,0 +1,9 @@
+
+tunnel: uuid-for-ollama
+#Optional
+#credentials-file: /etc/cloudflared/uuid-for-ollama.json
+
+ingress:
+  - hostname: 
+    service: http://ollama:11434
+  - service: http_status:404

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+
+  ollama:
+    image: ollama/ollama
+    expose:
+     - 11434/tcp
+    ports:
+     - 11434:11434/tcp
+    healthcheck:
+      test: ollama --version || exit 1
+    command: serve
+    container_name: ollama
+    pull_policy: always
+    tty: true
+    restart: always
+    volumes:
+      - ollama_data:/root/.ollama
+    environment:
+      - OLLAMA_API_BASE_URL=http://ollama:11434
+
+
+  ollama-tunnel:
+    image: cloudflare/cloudflared:latest
+    restart: unless-stopped
+    environment:
+      - TUNNEL_URL=http://ollama:11434
+    command: tunnel --no-autoupdate
+    volumes:
+      - ./cloudflared/config.yml:/etc/cloudflared/config.yml
+    depends_on:
+      - ollama
+
+volumes:
+  ollama_data:
+  cloudflared:

--- a/ollama/models.sh
+++ b/ollama/models.sh
@@ -1,0 +1,30 @@
+# bash script that runs commands in ollama container to download models
+
+# log into docker container
+docker exec -it ollama bash
+
+# download models
+## LLMs
+# ollama pull llama3.2:1b
+# ollama pull gemma3:1b
+ollama pull deepseek-r1:1.5b
+
+## Multi-Modal
+# ollama pull gemma3:4b
+
+## Embeddings
+ollama pull nomic-embed-text:latest
+ollama pull mxbai-embed-large:latest
+
+## Vision
+ollama pull granite3.2-vision:2b
+
+# ## Audio Generation
+# ollama pull so-vits-svc:latest
+
+# List all models
+# ollama list
+
+# exit docker container
+exit
+


### PR DESCRIPTION
###  🚀 What does this PR do?

This PR implements a Docker Compose setup with two containers:

- ollama: AI model server with GPU support (port 11434)
- ollama-tunnel: Secure Cloudflare tunnel for remote access

The configuration allows users to run various AI models locally while accessing them securely from anywhere through Cloudflare tunnels.

Changes:
- Added Docker Compose configuration for Ollama and Cloudflare tunnel
- Created cloudflared configuration template
- Added script for installing AI models


Fixes #1
